### PR TITLE
MAINT: deprecate pyfar 3.9 and 3.10

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## mesh2scattering
 
+- MAINT: deprecate pyfar 3.9 and 3.10 ([#80](https://github.com/ahms5/Mesh2scattering/pulls/80))
 - MAINT: remove restriction to pyfar version ([#75](https://github.com/ahms5/Mesh2scattering/pulls/75), [#78](https://github.com/ahms5/Mesh2scattering/pulls/78))
 - MAINT: move matplotlib dependency to documentation as it is not required for the main package ([#74](https://github.com/ahms5/Mesh2scattering/pulls/74))
 - DOC: remove obsolete dependency ``nbsphinx_link`` and use ``nbsphinx`` directly ([#76](https://github.com/ahms5/Mesh2scattering/pulls/76), [#79](https://github.com/ahms5/Mesh2scattering/pulls/79))

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use pip to install mesh2scattering
 pip install mesh2scattering
 ```
 
-(Requires Python 3.9 or higher)
+(Requires Python 3.11 or higher)
 
 For Windows the exe is downloaded automatically.
 For Linux and MacOS NumCalc is build automatically, note that this requires

--- a/mesh2scattering/input/EvaluationGrid.py
+++ b/mesh2scattering/input/EvaluationGrid.py
@@ -32,6 +32,8 @@ class EvaluationGrid():
         >>> import spharpy
         >>>
         >>> points = spharpy.samplings.lebedev(10)
+        >>> points.weights = spharpy.samplings.calculate_sampling_weights(
+        ...     points)
         >>> grid = m2s.input.EvaluationGrid.from_spherical(
         ...     points, "Lebedev_N10")
     """

--- a/mesh2scattering/input/input.py
+++ b/mesh2scattering/input/input.py
@@ -367,13 +367,13 @@ def _write_nc_inp(
                 curves += 1
                 fw(f"{curves} {len(materials[m]['freqs'])}\n")
                 for f, v in zip(materials[m]['freqs'],
-                                materials[m]['real']):
+                                materials[m]['real'], strict=True):
                     fw(f"{f} {v} 0.0\n")
                 # write curve for imaginary values
                 curves += 1
                 fw(f"{curves} {len(materials[m]['freqs'])}\n")
                 for f, v in zip(materials[m]['freqs'],
-                                materials[m]['imag']):
+                                materials[m]['imag'], strict=True):
                     fw(f"{f} {v} 0.0\n")
 
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Numerical calculation of surface scattering."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 keywords = [
     "acoustics",
     "pyfar",
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ tests = [
     "pytest",
     "pytest-cov",
     "watchdog",
-    "ruff==0.9.8",
+    "ruff==0.15.8",
     "coverage",
     "nbmake>=0.7.0",
     "mesh2scattering[examples]",


### PR DESCRIPTION
### Changes proposed in this pull request:

- deprecate pyfar 3.9 and 3.10
-
-
